### PR TITLE
Remove versions of dependent gems in development

### DIFF
--- a/twitter_api.gemspec
+++ b/twitter_api.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'simple_oauth'
 
-  spec.add_development_dependency 'bundler', '~> 1.13'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
OS Command Injection in Rake · CVE-2020-8130 · GitHub Advisory Database
https://github.com/advisories/GHSA-jppv-gw3r-w3q8

> There is an OS command injection vulnerability in Ruby Rake before 12.3.3 in Rake::FileList when supplying a filename that begins with the pipe character |.